### PR TITLE
Re-enabling travis test on osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,26 +32,26 @@ matrix:
         - lcov --list coverage.info # debug info
         # Uploading report to CodeCov
         - bash <(curl -s https://codecov.io/bash) -f coverage.info || echo "Codecov did not collect coverage reports"
-    - os: osx
-      osx_image: xcode11.4
-      compiler: clang
-      addons:
-        ssh_known_hosts: xgitlab.cels.anl.gov
-        homebrew:
-          packages:
-            - git-lfs
-            - tbb
-          update: true
-    - os: osx
-      osx_image: xcode11.4
-      compiler: gcc
-      addons:
-        ssh_known_hosts: xgitlab.cels.anl.gov
-        homebrew:
-          packages:
-            - git-lfs
-            - tbb
-          update: true
+    # - os: osx
+    #   osx_image: xcode11.4
+    #   compiler: clang
+    #   addons:
+    #     ssh_known_hosts: xgitlab.cels.anl.gov
+    #     homebrew:
+    #       packages:
+    #         - git-lfs
+    #         - tbb
+    #       update: true
+    # - os: osx
+    #   osx_image: xcode11.4
+    #   compiler: gcc
+    #   addons:
+    #     ssh_known_hosts: xgitlab.cels.anl.gov
+    #     homebrew:
+    #       packages:
+    #         - git-lfs
+    #         - tbb
+    #       update: true
 
 before_install:
   - openssl aes-256-cbc -K $encrypted_db2095f63ba3_key -iv $encrypted_db2095f63ba3_iv -in deploy_rsa.enc -out /tmp/deploy_rsa -d

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,6 @@ before_install:
   - cd DSPThirdPartyLibs
   - ./travis.sh
   - if [ $TRAVIS_OS_NAME == linux ]; then export LD_LIBRARY_PATH=$PWD/lib:$(dirname `gfortran --print-file-name libgfortran.so`):$LD_LIBRARY_PATH; fi
-  # - if [ $TRAVIS_OS_NAME == osx ]; then export DYLD_LIBRARY_PATH=$PWD/lib:$(dirname `gfortran --print-file-name libgfortran.dylib`):$DYLD_LIBRARY_PATH; fi
   - if [ $TRAVIS_OS_NAME == osx ]; then export DYLD_LIBRARY_PATH=$PWD/scip/build/lib:$(dirname `gfortran --print-file-name libgfortran.dylib`):$DYLD_LIBRARY_PATH; fi
   - cd ..
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,6 @@ matrix:
         # Uploading report to CodeCov
         - bash <(curl -s https://codecov.io/bash) -f coverage.info || echo "Codecov did not collect coverage reports"
     - os: osx
-      # osx_image: xcode11.4
       compiler: clang
       addons:
         ssh_known_hosts: xgitlab.cels.anl.gov
@@ -46,7 +45,6 @@ matrix:
             - ccache
           update: true
     - os: osx
-      # osx_image: xcode11.4
       compiler: gcc
       addons:
         ssh_known_hosts: xgitlab.cels.anl.gov
@@ -58,7 +56,13 @@ matrix:
           update: true
 
 before_install:
+  # add environment variable for ccache on osx
   - if [ $TRAVIS_OS_NAME == osx ]; then export PATH="/usr/local/opt/ccache/libexec:$PATH"; fi
+
+  # print cache statistics
+  - ccache --show-stats
+  
+  # download and compile private dependencies
   - openssl aes-256-cbc -K $encrypted_db2095f63ba3_key -iv $encrypted_db2095f63ba3_iv -in deploy_rsa.enc -out /tmp/deploy_rsa -d
   - eval "$(ssh-agent -s)"
   - chmod 600 /tmp/deploy_rsa
@@ -70,6 +74,9 @@ before_install:
   - if [ $TRAVIS_OS_NAME == linux ]; then export LD_LIBRARY_PATH=$PWD/lib:$(dirname `gfortran --print-file-name libgfortran.so`):$LD_LIBRARY_PATH; fi
   - if [ $TRAVIS_OS_NAME == osx ]; then export DYLD_LIBRARY_PATH=$PWD/scip/build/lib:$(dirname `gfortran --print-file-name libgfortran.dylib`):$DYLD_LIBRARY_PATH; fi
   - cd ..
+
+  # print final cache statistics
+  - ccache --show-stats
 
 install:
   - mkdir build && cd build && cmake .. -DUNIT_TESTING=ON -DCODE_COVERAGE=ON -DCMAKE_BUILD_TYPE=DEBUG

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: cpp
 
+cache: ccache
+
 matrix:
   include:
     - os: linux
@@ -32,28 +34,31 @@ matrix:
         - lcov --list coverage.info # debug info
         # Uploading report to CodeCov
         - bash <(curl -s https://codecov.io/bash) -f coverage.info || echo "Codecov did not collect coverage reports"
-    # - os: osx
-    #   osx_image: xcode11.4
-    #   compiler: clang
-    #   addons:
-    #     ssh_known_hosts: xgitlab.cels.anl.gov
-    #     homebrew:
-    #       packages:
-    #         - git-lfs
-    #         - tbb
-    #       update: true
-    # - os: osx
-    #   osx_image: xcode11.4
-    #   compiler: gcc
-    #   addons:
-    #     ssh_known_hosts: xgitlab.cels.anl.gov
-    #     homebrew:
-    #       packages:
-    #         - git-lfs
-    #         - tbb
-    #       update: true
+    - os: osx
+      # osx_image: xcode11.4
+      compiler: clang
+      addons:
+        ssh_known_hosts: xgitlab.cels.anl.gov
+        homebrew:
+          packages:
+            - git-lfs
+            - tbb
+            - ccache
+          update: true
+    - os: osx
+      # osx_image: xcode11.4
+      compiler: gcc
+      addons:
+        ssh_known_hosts: xgitlab.cels.anl.gov
+        homebrew:
+          packages:
+            - git-lfs
+            - tbb
+            - ccache
+          update: true
 
 before_install:
+  - if [ $TRAVIS_OS_NAME == osx ]; then export PATH="/usr/local/opt/ccache/libexec:$PATH"; fi
   - openssl aes-256-cbc -K $encrypted_db2095f63ba3_key -iv $encrypted_db2095f63ba3_iv -in deploy_rsa.enc -out /tmp/deploy_rsa -d
   - eval "$(ssh-agent -s)"
   - chmod 600 /tmp/deploy_rsa

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,8 +68,8 @@ before_install:
   - cd DSPThirdPartyLibs
   - ./travis.sh
   - if [ $TRAVIS_OS_NAME == linux ]; then export LD_LIBRARY_PATH=$PWD/lib:$(dirname `gfortran --print-file-name libgfortran.so`):$LD_LIBRARY_PATH; fi
-  - if [ $TRAVIS_OS_NAME == osx ]; then export DYLD_LIBRARY_PATH=$PWD/lib:$(dirname `gfortran --print-file-name libgfortran.dylib`):$DYLD_LIBRARY_PATH; fi
-  # - if [ $TRAVIS_OS_NAME == osx ]; then export DYLD_LIBRARY_PATH=$PWD/scip/build/lib:$(dirname `gfortran --print-file-name libgfortran.dylib`):$DYLD_LIBRARY_PATH; fi
+  # - if [ $TRAVIS_OS_NAME == osx ]; then export DYLD_LIBRARY_PATH=$PWD/lib:$(dirname `gfortran --print-file-name libgfortran.dylib`):$DYLD_LIBRARY_PATH; fi
+  - if [ $TRAVIS_OS_NAME == osx ]; then export DYLD_LIBRARY_PATH=$PWD/scip/build/lib:$(dirname `gfortran --print-file-name libgfortran.dylib`):$DYLD_LIBRARY_PATH; fi
   - cd ..
 
 install:
@@ -78,5 +78,5 @@ install:
   - make install
 
 script:
-  - ctest -R scip_farmer_bd --verbose
+  - ctest
   - ./src/test/UnitTests


### PR DESCRIPTION
- use scip 7.0.1; but, I could not avoid to compile scip from the source.
- use `ccache` in travis; this seems to save some time.