### PR TITLE
Support for distributed subproblem data

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -6,6 +6,7 @@ on:
     - 'README.md'
     - '**.yml'
     - 'docs/**'
+    - 'src/DspConfig.h'
   pull_request:
     branches:
       - master

--- a/src/DspConfig.h
+++ b/src/DspConfig.h
@@ -18,7 +18,7 @@ inline void show_copyright()
                  "  - Version %d.%d.%d\n"
                  "  - See https://github.com/Argonne-National-Laboratory/DSP\n\n"
                  "  Under the terms of Contract No. DE-AC02-06CH11357 with UChicago Argonne, LLC,\n"
-                 "  the U.S. Government retains certain rights in this software.\n\n"
+                 "  the U.S. Government retains certain rights in this software.\n"
                  "=================================================================================\n",
             DSP_VERSION_MAJOR, DSP_VERSION_MINOR, DSP_VERSION_PATCH);
     printf("%s", msg);

--- a/src/Model/DecBlkModel.cpp
+++ b/src/Model/DecBlkModel.cpp
@@ -27,6 +27,15 @@ DecBlkModel::~DecBlkModel() {
 	FREE_PTR(blk_);
 }
 
+bool DecBlkModel::isDistributed()
+{
+	/** FIXME: There is no way to check this condition. */
+	char msg[] = "This function (DecBlkModel::isDistributed()) should not be used.\n"
+				 "There is no way to check whether or not subproblems are distributed for generic block structure.\n";
+	printf("%s".msg);
+	return false;
+}
+
 double DecBlkModel::evalLhsCouplingRow(int row, double** solutions) {
 	double val = 0.0;
 	for (int i = 0; i < blk_->getNumBlocks() - 1; ++i)

--- a/src/Model/DecBlkModel.cpp
+++ b/src/Model/DecBlkModel.cpp
@@ -32,7 +32,7 @@ bool DecBlkModel::isDistributed()
 	/** FIXME: There is no way to check this condition. */
 	char msg[] = "This function (DecBlkModel::isDistributed()) should not be used.\n"
 				 "There is no way to check whether or not subproblems are distributed for generic block structure.\n";
-	printf("%s".msg);
+	printf("%s", msg);
 	return false;
 }
 

--- a/src/Model/DecBlkModel.h
+++ b/src/Model/DecBlkModel.h
@@ -72,7 +72,8 @@ public:
 
 	bool isStochastic() {return false;}
 	virtual void setDro(bool yes) { ; }
-	bool isDro() {return false;}
+	virtual bool isDro() { return false; }
+	virtual bool isDistributed();
 	int getNumReferences() {return 0;}
 	double getWassersteinSize() {return 0.0;}
 	double getWassersteinDist(int i, int j) {return 0.0;}

--- a/src/Model/DecModel.h
+++ b/src/Model/DecModel.h
@@ -187,6 +187,11 @@ public:
 	virtual bool isDro() = 0;
 
 	/**
+	 * If true, the subproblem data is distributed.
+	 */
+	virtual bool isDistributed() = 0;
+
+	/**
 	 * Returns the number of reference scenarios (for DRO).
 	 */
 	virtual int getNumReferences() = 0;

--- a/src/Model/DecTssModel.cpp
+++ b/src/Model/DecTssModel.cpp
@@ -32,6 +32,18 @@ DecTssModel::~DecTssModel() {
 	FREE_ARRAY_PTR(master_col_indices_);
 }
 
+bool DecTssModel::isDistributed()
+{
+	bool is_distributed = false;
+	for (int s = 0; s < nscen_; ++s)
+		if (mat_scen_[s] == NULL)
+		{
+			is_distributed = true;
+			break;
+		}
+	return is_distributed;
+}
+
 DSP_RTN_CODE DecTssModel::decompose(
 	int size,                    /**< [in] size of subproblem subset */
 	int * scen,                  /**< [in] subset of scenarios */

--- a/src/Model/DecTssModel.h
+++ b/src/Model/DecTssModel.h
@@ -151,6 +151,9 @@ public:
 	// TODO: Better to create a new inhereted class?
 	virtual void setDro(bool yes) { TssModel::setDro(yes); }
 	virtual bool isDro() {return TssModel::isDro();}
+
+	virtual bool isDistributed();
+
 	virtual int getNumReferences() {return TssModel::getNumReferences();}
 	virtual double getWassersteinSize() {return TssModel::getWassersteinSize();}
 	virtual double getWassersteinDist(int i, int j) {return TssModel::getWassersteinDist(i,j);}

--- a/src/Model/StoModel.cpp
+++ b/src/Model/StoModel.cpp
@@ -1017,6 +1017,11 @@ bool StoModel::mapVarnameIndex(map<string, int> &map_varName_index, const char *
 	return true;
 }
 
+void StoModel::setProbability(double *probability)
+{
+	CoinCopyN(probability, nscen_, prob_);
+}
+
 void StoModel::setSolution(int size, double * solution)
 {
 	if (size > 0)

--- a/src/Model/StoModel.h
+++ b/src/Model/StoModel.h
@@ -200,6 +200,9 @@ public:
 	bool hasQuadraticRowCore() const {return qc_row_core_ != NULL ? true : false;};
 	bool hasQuadraticRowScenario() const {return qc_row_scen_ != NULL ? true : false;};
 
+	/** set probability */
+	void setProbability(double *probability);
+
 	/** set initial solutions */
 	void setSolution(
 			int      size,    /**< size of array */

--- a/src/Solver/DantzigWolfe/DwModelSmip.cpp
+++ b/src/Solver/DantzigWolfe/DwModelSmip.cpp
@@ -22,7 +22,7 @@ DwModel() {
 DwModelSmip::DwModelSmip(DecSolver* solver):
 DwModel(solver) {
     tss_ = dynamic_cast<TssModel*>(solver_->getModelPtr());
-	printf("DwModelSmip constructor.\n");
+	// printf("DwModelSmip constructor.\n");
 }
 
 DwModelSmip::~DwModelSmip() {
@@ -37,8 +37,8 @@ DSP_RTN_CODE DwModelSmip::initBranch() {
             branch_ = new DwBranchNonant(this);
             break;
         case BRANCH_NONANT2:
-			printf("Created BRANCH_NONANT2 rule.\n");
-            branch_ = new DwBranchNonant2(this);
+			// printf("Created BRANCH_NONANT2 rule.\n");
+			branch_ = new DwBranchNonant2(this);
             break;
         case BRANCH_DISJUNCTION_TEST:
             printf("\n*** WARNING: This is a testing code for branching on general disjunctions. ***\n\n");

--- a/src/Solver/DantzigWolfe/DwWorker.cpp
+++ b/src/Solver/DantzigWolfe/DwWorker.cpp
@@ -26,13 +26,15 @@ DwWorker::DwWorker(DecModel * model, DspParams * par, DspMessage * message) :
 	parProcIdx_     = par_->getIntPtrParam("ARR_PROC_IDX");
 	DSPdebugMessage("Created parameters, DwWorker.\n");
 
-	if (parProcIdxSize_ <= 0) {
-		throw CoinError("Parameter ARR_PROC_IDX should be assigned.", "DwWorker", "DwWorker.cpp");
-	}
-
 	/** number of total subproblems */
 	nsubprobs_ = parProcIdxSize_;
 	DSPdebugMessage("nsubprobs_ %d\n", nsubprobs_);
+
+	if (parProcIdxSize_ <= 0)
+	{
+		// throw CoinError("Parameter ARR_PROC_IDX should be assigned.", "DwWorker", "DwWorker.cpp");
+		return;
+	}
 
 	/** create subproblem solver */
 	//sub_ = new DwSub();
@@ -102,12 +104,15 @@ DwWorker::DwWorker(DecModel * model, DspParams * par, DspMessage * message) :
 }
 
 DwWorker::~DwWorker() {
-	FREE_2D_PTR(parProcIdxSize_, osi_);
-	//FREE_PTR(sub_);
-	FREE_2D_ARRAY_PTR(parProcIdxSize_, sub_objs_);
-	FREE_2D_ARRAY_PTR(parProcIdxSize_, sub_clbd_);
-	FREE_2D_ARRAY_PTR(parProcIdxSize_, sub_cubd_);
-	FREE_2D_ARRAY_PTR(parProcIdxSize_, coupled_);
+	if (parProcIdxSize_ > 0)
+	{
+		FREE_2D_PTR(parProcIdxSize_, osi_);
+		//FREE_PTR(sub_);
+		FREE_2D_ARRAY_PTR(parProcIdxSize_, sub_objs_);
+		FREE_2D_ARRAY_PTR(parProcIdxSize_, sub_clbd_);
+		FREE_2D_ARRAY_PTR(parProcIdxSize_, sub_cubd_);
+		FREE_2D_ARRAY_PTR(parProcIdxSize_, coupled_);
+	}
 }
 
 DSP_RTN_CODE DwWorker::createSubproblems() {

--- a/src/Solver/DantzigWolfe/DwWorkerMpi.cpp
+++ b/src/Solver/DantzigWolfe/DwWorkerMpi.cpp
@@ -172,10 +172,13 @@ DSP_RTN_CODE DwWorkerMpi::generateCols(
 	MPI_Allreduce(&maxstops_s, &maxstops_r, 1, MPI_INT, MPI_MAX, comm_);
 	std::fill(num_timelim_stops_.begin(), num_timelim_stops_.end(), maxstops_r);
 
-	DSP_RTN_CHECK_RTN_CODE(
-			DwWorker::generateCols(phase, piA_, indices, statuses, cxs, objs, sols));
-	DSPdebugMessage("Rank %d generated %lu indices, %lu statuses, %lu cxs, %lu objs, and %lu sols.\n",
-			comm_rank_, indices.size(), statuses.size(), cxs.size(), objs.size(), sols.size());
+	if (parProcIdxSize_ > 0)
+	{
+		DSP_RTN_CHECK_RTN_CODE(
+				DwWorker::generateCols(phase, piA_, indices, statuses, cxs, objs, sols));
+		DSPdebugMessage("Rank %d generated %lu indices, %lu statuses, %lu cxs, %lu objs, and %lu sols.\n",
+				comm_rank_, indices.size(), statuses.size(), cxs.size(), objs.size(), sols.size());
+	}
 
 	/** The root rank gathers the number of subproblems for each process. */
 	MPI_Gather(&parProcIdxSize_, 1, MPI_INT, recvcounts, 1, MPI_INT, 0, comm_);
@@ -282,10 +285,13 @@ DSP_RTN_CODE DwWorkerMpi::generateColsByFix(
 	MPI_Bcast(_x, tss->getNumCols(0), MPI_DOUBLE, 0, comm_);
 
 	/** actual function to generate columns */
-	DSP_RTN_CHECK_RTN_CODE(
+	if (parProcIdxSize_ > 0)
+	{
+		DSP_RTN_CHECK_RTN_CODE(
 			DwWorker::generateColsByFix(_x, indices, statuses, objs, sols));
-	DSPdebugMessage("Rank %d generated %lu indices, %lu statuses, %lu objs, and %lu sols.\n",
-			comm_rank_, indices.size(), statuses.size(), objs.size(), sols.size());
+		DSPdebugMessage("Rank %d generated %lu indices, %lu statuses, %lu objs, and %lu sols.\n",
+								comm_rank_, indices.size(), statuses.size(), objs.size(), sols.size());
+	}
 
 	/** The root rank gathers the number of subproblems for each process. */
 	MPI_Gather(&parProcIdxSize_, 1, MPI_INT, recvcounts, 1, MPI_INT, 0, comm_);

--- a/src/Solver/DualDecomp/DdMWSync.cpp
+++ b/src/Solver/DualDecomp/DdMWSync.cpp
@@ -90,7 +90,7 @@ DSP_RTN_CODE DdMWSync::init()
 		}
 		/** initialize workers */
 		for (unsigned i = 0; i < worker_.size(); ++i)
-			worker_[i]->init();
+			DSP_RTN_CHECK_THROW(worker_[i]->init());
 	}
 
         /** reset iteration info */

--- a/src/Solver/DualDecomp/DdMasterTr.cpp
+++ b/src/Solver/DualDecomp/DdMasterTr.cpp
@@ -180,15 +180,15 @@ DSP_RTN_CODE DdMasterTr::solve()
 			message_->print(3, "Master solution time %.2f sec.\n", CoinGetTimeOfDay() - walltime);
 
 			resolve = false;
-			DSPdebug(getSiPtr()->writeMps("master"));
-	
+			// DSPdebug(getSiPtr()->writeMps("master"));
+
 			break;
 		}
 		default:
 			message_->print(0, "Warning: master solution status is %d\n", status_);
 			status_ = DSP_STAT_MW_STOP;
 			resolve = false;
-			DSPdebug(getSiPtr()->writeMps("master"));
+			// DSPdebug(getSiPtr()->writeMps("master"));
 			break;
 		}
 	}

--- a/src/dsp.cpp
+++ b/src/dsp.cpp
@@ -170,7 +170,7 @@ int runDsp(char *algotype, char *smpsfile, char *mpsfile, char *decfile, char *s
 			cout << "Second stage: " << getNumRows(env, 1) << " rows, " << getNumCols(env, 1) << " cols, " << getNumIntegers(env, 1) << " integers" << endl;
 			cout << "Number of scenarios: " << getNumSubproblems(env) << endl;
 		}
-		setBlockIds(env, getNumSubproblems(env), true);
+		setBlockIds(env, getNumSubproblems(env), false);
 	}
 	else if (mpsfile != NULL && decfile != NULL)
 	{

--- a/src/test/src/tests-DspCInterface.cpp
+++ b/src/test/src/tests-DspCInterface.cpp
@@ -19,9 +19,9 @@ TEST_CASE("C interface functions") {
         int minor = getVersionMinor(env);
         int patch = getVersionPatch(env);
 
-        REQUIRE(major == DSP_VERSION_MAJOR);
-        REQUIRE(minor == DSP_VERSION_MINOR);
-        REQUIRE(patch == DSP_VERSION_PATCH);
+        CHECK(major == DSP_VERSION_MAJOR);
+        CHECK(minor == DSP_VERSION_MINOR);
+        CHECK(patch == DSP_VERSION_PATCH);
     }
 
     SECTION("freeEnv function") {


### PR DESCRIPTION
We define *distributed subproblem data* as that each process has only a part (vs. all) of the subproblem data when running in parallel. For example, when solving 3-scenario stochastic program with 4 processes, the master (rank 0) creates no scenario subproblem, and each of the other processes creates only one mutually exclusive scenario subproblem. Hence, the computing can save memory by creating the relevant subproblems only.

However, the distributed subproblem data is possible only for `bd` and `dd` because the other methods (i.e., `dw` and `dr*`) require all the subproblem data for either creating the Dantzig-Wolfe master problem (in `dw`) or computing the Wasserstein distances (in `dr*`). While these may also be addressed in future, we disable it for these methods with messages in this PR.