### PR TITLE
fixed primal recourse obj not getting updated

### DIFF
--- a/src/Solver/DualDecomp/DdWorkerUB.cpp
+++ b/src/Solver/DualDecomp/DdWorkerUB.cpp
@@ -138,7 +138,6 @@ DSP_RTN_CODE DdWorkerUB::createProblem()
 			if (ctype_reco[j] != 'C')
 			{
 				has_integer = true;
-				break;
 			}
 		}
 


### PR DESCRIPTION
There was a break statement after checking that a recourse variable is not continuous, preventing the rescaling of the recourse objective by the probability of the subproblem. Fixes #254 