### PR TITLE
Termination of DW decomposition when unbounded ray is called

### DIFF
--- a/examples/cpp/farmer.cpp
+++ b/examples/cpp/farmer.cpp
@@ -148,16 +148,16 @@ int main(int argc, char **argv)
         ))dlsym(handle, "loadBlockProblem"))(
             env,
             block + 1,
-            0,
+            nvars,
             ncons1,
             start1[ncons1],
             start1,
             index_,
             value_,
-            NULL,
-            NULL,
-            NULL,
-            NULL,
+            clbd0,
+            cubd0,
+            ctype0,
+            obj0,
             rlbd1,
             rubd1
         );

--- a/src/Solver/DantzigWolfe/DwWorker.cpp
+++ b/src/Solver/DantzigWolfe/DwWorker.cpp
@@ -277,27 +277,15 @@ DSP_RTN_CODE DwWorker::generateCols(
 
 				switch(par_->getIntParam("DW/SUB/SOLVER")) {
 				case OsiCpx:
-#ifdef DSP_HAS_CPX
 					rays = osi_[s]->si_->getPrimalRays(1);
-#else
-					throw CoinError("Cplex is not available.", "DwWorker", "DwWorker.cpp");
-#endif
 					break;
 				case OsiGrb:
-#ifdef DSP_HAS_GRB
 					// rays = osi_[s]->si_->getPrimalRays(1);
 					throw CoinError("getPrimalRays not implemented in Gurobi.", "DwWorker", "DwWorker.cpp");
-#else
-					throw CoinError("Gurobi is not available.", "DwWorker", "DwWorker.cpp");
-#endif
 					break;
 				case OsiScip:
-#ifdef DSP_HAS_SCIP
 					// rays = osi_[s]->si_->getPrimalRays(1);
 					throw CoinError("getPrimalRays not implemented in Scip.", "DwWorker", "DwWorker.cpp");
-#else
-					throw CoinError("Scip is not available.", "DwWorker", "DwWorker.cpp");
-#endif
 					break;
 				default:
 					throw CoinError("Invalid paramter value", "DwWorker", "DwWorker.cpp");

--- a/src/Solver/DantzigWolfe/DwWorker.cpp
+++ b/src/Solver/DantzigWolfe/DwWorker.cpp
@@ -273,11 +273,43 @@ DSP_RTN_CODE DwWorker::generateCols(
 
 			if (status == DSP_STAT_DUAL_INFEASIBLE) {
 				/** retrieve ray if unbounded */
-				std::vector<double*> rays = osi_[s]->si_->getPrimalRays(1);
+				std::vector<double*> rays;
+
+				switch(par_->getIntParam("DW/SUB/SOLVER")) {
+				case OsiCpx:
+#ifdef DSP_HAS_CPX
+					rays = osi_[s]->si_->getPrimalRays(1);
+#else
+					throw CoinError("Cplex is not available.", "DwWorker", "DwWorker.cpp");
+#endif
+					break;
+				case OsiGrb:
+#ifdef DSP_HAS_GRB
+					// rays = osi_[s]->si_->getPrimalRays(1);
+					throw CoinError("getPrimalRays not implemented in Gurobi.", "DwWorker", "DwWorker.cpp");
+#else
+					throw CoinError("Gurobi is not available.", "DwWorker", "DwWorker.cpp");
+#endif
+					break;
+				case OsiScip:
+#ifdef DSP_HAS_SCIP
+					// rays = osi_[s]->si_->getPrimalRays(1);
+					throw CoinError("getPrimalRays not implemented in Scip.", "DwWorker", "DwWorker.cpp");
+#else
+					throw CoinError("Scip is not available.", "DwWorker", "DwWorker.cpp");
+#endif
+					break;
+				default:
+					throw CoinError("Invalid paramter value", "DwWorker", "DwWorker.cpp");
+					break;
+				}
+
 				if (rays.size() == 0 || rays[0] == NULL)
 					throw CoinError("No primal ray is available.", "generateCols", "DwWorker");
 				double* ray = rays[0];
 				rays[0] = NULL;
+				DSPdebugMessage("unbounded ray\n");
+				DSPdebug(DspMessage::printArray(osi_[s]->si_->getNumCols(), ray));
 
 				/** subproblem objective value */
 				cx = 0.0;


### PR DESCRIPTION
Clp, Cpx, Msk have implementation of `getPrimalRays`. We allow only Cpx. If Gurobi or Scip is used, we call CoinError.
Addresses issue #265.