### PR TITLE
Termination for getPrimalRays call depending on solver

### DIFF
--- a/examples/cpp/Makefile
+++ b/examples/cpp/Makefile
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+CXX=g++
+INCDIR=../../build/include
+
+all: farmer_*.cpp
+	$(CXX) -o farmer farmer.cpp
+	$(CXX) -o farmer_dec farmer_dec.cpp

--- a/examples/cpp/farmer.cpp
+++ b/examples/cpp/farmer.cpp
@@ -1,0 +1,201 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <dlfcn.h>
+
+/*
+Farmer example: This is based on a well-known stochastic programming problem.
+
+minimize 1/3 * (150 x11 + 230 x21 + 260 x31 + 238 y11 + 210 y21 - 170 w11 - 150 w21 - 36 w31 - 10 w41)
+       + 1/3 * (150 x12 + 230 x22 + 260 x32 + 238 y12 + 210 y22 - 170 w12 - 150 w22 - 36 w32 - 10 w42)
+       + 1/3 * (150 x13 + 230 x23 + 260 x33 + 238 y13 + 210 y23 - 170 w13 - 150 w23 - 36 w33 - 10 w43)
+subject to
+  x11             - x12                               == 0
+        x21             - x22                         == 0
+              x31             - x32                   == 0
+                    x12             - x13             == 0
+                          x22             - x23       == 0
+                                x32             - x33 == 0
+  x11 + x21 + x31                                     <= 500
+  
+Each block has the following constraint matrix and the common row bound vectors:
+
+    A1 = [3.0         1.0     -1.0               ]
+         [    3.6         1.0      -1.0          ]
+         [         24                   -1.0 -1.0]
+         [                               1.0     ]
+
+    A2 = [2.5         1.0     -1.0               ]
+         [    3.0         1.0      -1.0          ]
+         [         20                   -1.0 -1.0]
+         [                               1.0     ]
+
+    A3 = [2.0         1.0     -1.0               ]
+         [    2.4         1.0      -1.0          ]
+         [         16                   -1.0 -1.0]
+         [                               1.0     ]
+
+    bl = [200 240 0.0 -Inf]
+    bu = [Inf Inf Inf 6000]
+*/
+
+int main(int argc, char **argv)
+{
+    void *handle;
+    char *error;
+
+    // Load the library
+    handle = dlopen("libDsp.dylib", RTLD_LAZY);
+    if (!handle) {
+        fputs (dlerror(), stderr);
+        exit(1);
+    }
+
+    void* env = NULL;
+    env = ((void *(*)())dlsym(handle, "createEnv"))();
+    if (env == NULL) {
+        printf("Failed to create DSP environment.\n");
+    } else {
+        printf("Successfully created DSP environment.\n");
+    }
+
+    // Problem Data
+    int nvars = 27;
+    int ncons0 = 7;
+    int ncons1 = 4;
+    double obj[] = {150/3, 230/3, 260/3, 238/3, 210/3, -170/3, -150/3, -36/3, -10/3};
+    double rlbd0[] = {0, 0, 0, 0, 0, 0, -1e+20};
+    double rubd0[] = {0, 0, 0, 0, 0, 0, 500};
+    double rlbd1[] = {200, 240, 0, -1e+20};
+    double rubd1[] = {1e+20, 1e+20, 1e+20, 6000};
+    int start0[] = {0, 2, 4, 6, 8, 10, 12, 15};
+    int index0[] = {0, 9, 1, 10, 2, 11, 9, 18, 10, 19, 11, 20, 0, 1, 2};
+    double value0[] = {1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1, 1, 1};
+    int start1[] = {0, 3, 6, 9, 10};
+    int index1[] = {0, 3, 5, 1, 4, 6, 2, 7, 8, 7};
+    double value1[] = {3, 1, -1, 3.6, 1, -1, 24, -1, -1, 1};
+    double value2[] = {2.5, 1, -1, 3, 1, -1, 20, -1, -1, 1};
+    double value3[] = {2, 1, -1, 2.4, 1, -1, 16, -1, -1, 1};
+
+    double *obj0 = new double [nvars];
+    double *clbd0 = new double [nvars];
+    double *cubd0 = new double [nvars];
+    char *ctype0 = new char [nvars];
+    for (int j = 0; j < nvars; ++j) {
+        obj0[j] = obj[j % 9];
+        clbd0[j] = 0.0;
+        cubd0[j] = 1e+20;
+        ctype0[j] = j % 9 < 3 ? 'I' : 'C';
+    }
+
+    ((void (*)(
+        void *,
+        int,
+        int,
+        int,
+        int,
+        int*,
+        int*,
+        double*,
+        double*,
+        double*,
+        char*,
+        double*,
+        double*,
+        double*
+    ))dlsym(handle, "loadBlockProblem"))(
+        env,
+        0,
+        nvars,
+        ncons0,
+        start0[ncons0],
+        start0,
+        index0,
+        value0,
+        clbd0,
+        cubd0,
+        ctype0,
+        obj0,
+        rlbd0,
+        rubd0
+    );
+
+    int *index_ = new int [start1[ncons1]];
+    double *value_ = new double [start1[ncons1]];
+
+    // create each block
+    for (int block = 0; block < 3; block++) {
+        for (int j = 0; j < start1[ncons1]; ++j) {
+            index_[j] = index1[j] + block * 9;
+            if (block == 0) value_[j] = value1[j];
+            else if (block == 1) value_[j] = value2[j];
+            else if (block == 2) value_[j] = value3[j];
+        }
+        ((void (*)(
+            void *,
+            int,
+            int,
+            int,
+            int,
+            int*,
+            int*,
+            double*,
+            double*,
+            double*,
+            char*,
+            double*,
+            double*,
+            double*
+        ))dlsym(handle, "loadBlockProblem"))(
+            env,
+            block + 1,
+            0,
+            ncons1,
+            start1[ncons1],
+            start1,
+            index_,
+            value_,
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            rlbd1,
+            rubd1
+        );
+    }
+
+    // Important to call this!
+    ((void (*)(void*))dlsym(handle, "updateBlocks"))(env);
+
+    // Solve the deterministic equivalent problem
+    ((void (*)(void*))dlsym(handle, "solveDe"))(env);
+
+    // FIXME: This causes segfault, probably due to incorrectly addressing unbounded subproblem solution.
+    // ((void (*)(void*))dlsym(handle, "solveDw"))(env);
+
+    double primal_bound = ((double (*)(void*))dlsym(handle, "getPrimalBound"))(env);
+    printf("Primal bound = %e\n", primal_bound);
+
+    double *solution = new double [nvars];
+    ((void (*)(void*, int, double*))dlsym(handle, "getPrimalSolution"))(env, nvars, solution);
+    for (int j = 0; j < nvars; ++j) {
+        printf("var%2d = %f\n", j, solution[j]);
+    }
+    // ((void (*)(void*, const char*))dlsym(handle, "writeMps"))(env, "farmer");
+    
+    if (env != NULL) {
+        ((void (*)(void*&))dlsym(handle, "freeEnv"))(env);
+        env = NULL;
+        printf("Successfully freed DSP environment.\n");
+    }
+    dlclose(handle);
+
+    delete [] obj0;
+    delete [] clbd0;
+    delete [] cubd0;
+    delete [] ctype0;
+    delete [] index_;
+    delete [] value_;
+    delete [] solution;
+
+    return 0;
+}

--- a/examples/cpp/farmer_dec.cpp
+++ b/examples/cpp/farmer_dec.cpp
@@ -1,0 +1,201 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <dlfcn.h>
+
+/*
+Farmer example: This is based on a well-known stochastic programming problem.
+
+minimize 1/3 * (150 x11 + 230 x21 + 260 x31 + 238 y11 + 210 y21 - 170 w11 - 150 w21 - 36 w31 - 10 w41)
+       + 1/3 * (150 x12 + 230 x22 + 260 x32 + 238 y12 + 210 y22 - 170 w12 - 150 w22 - 36 w32 - 10 w42)
+       + 1/3 * (150 x13 + 230 x23 + 260 x33 + 238 y13 + 210 y23 - 170 w13 - 150 w23 - 36 w33 - 10 w43)
+subject to
+  x11             - x12                               == 0
+        x21             - x22                         == 0
+              x31             - x32                   == 0
+                    x12             - x13             == 0
+                          x22             - x23       == 0
+                                x32             - x33 == 0
+  
+Each block has the following constraint matrix and the common row bound vectors:
+
+    A1 = [1   1    1                             ]
+         [3.0         1.0     -1.0               ]
+         [    3.6         1.0      -1.0          ]
+         [         24                   -1.0 -1.0]
+         [                               1.0     ]
+
+    A2 = [1   1    1                             ]
+         [2.5         1.0     -1.0               ]
+         [    3.0         1.0      -1.0          ]
+         [         20                   -1.0 -1.0]
+         [                               1.0     ]
+
+    A3 = [1   1    1                             ]
+         [2.0         1.0     -1.0               ]
+         [    2.4         1.0      -1.0          ]
+         [         16                   -1.0 -1.0]
+         [                               1.0     ]
+
+    bl = [-Inf 200 240 0.0 -Inf]
+    bu = [500  Inf Inf Inf 6000]
+*/
+
+int main(int argc, char **argv)
+{
+    void *handle;
+    char *error;
+
+    // Load the library
+    handle = dlopen("libDsp.dylib", RTLD_LAZY);
+    if (!handle) {
+        fputs (dlerror(), stderr);
+        exit(1);
+    }
+
+    void* env = NULL;
+    env = ((void *(*)())dlsym(handle, "createEnv"))();
+    if (env == NULL) {
+        printf("Failed to create DSP environment.\n");
+    } else {
+        printf("Successfully created DSP environment.\n");
+    }
+
+    // Problem Data
+    int nvars = 27;
+    int ncons0 = 6;
+    int ncons1 = 5;
+    double obj[] = {150/3, 230/3, 260/3, 238/3, 210/3, -170/3, -150/3, -36/3, -10/3};
+    double rlbd0[] = {0, 0, 0, 0, 0, 0};
+    double rubd0[] = {0, 0, 0, 0, 0, 0};
+    double rlbd1[] = {-1e+20, 200, 240, 0, -1e+20};
+    double rubd1[] = {500, 1e+20, 1e+20, 1e+20, 6000};
+    int start0[] = {0, 2, 4, 6, 8, 10, 12};
+    int index0[] = {0, 9, 1, 10, 2, 11, 9, 18, 10, 19, 11, 20};
+    double value0[] = {1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1};
+    int start1[] = {0, 3, 6, 9, 12, 13};
+    int index1[] = {0, 1, 2, 0, 3, 5, 1, 4, 6, 2, 7, 8, 7};
+    double value1[] = {1, 1, 1, 3, 1, -1, 3.6, 1, -1, 24, -1, -1, 1};
+    double value2[] = {1, 1, 1, 2.5, 1, -1, 3, 1, -1, 20, -1, -1, 1};
+    double value3[] = {1, 1, 1, 2, 1, -1, 2.4, 1, -1, 16, -1, -1, 1};
+
+    double *obj0 = new double [nvars];
+    double *clbd0 = new double [nvars];
+    double *cubd0 = new double [nvars];
+    char *ctype0 = new char [nvars];
+    for (int j = 0; j < nvars; ++j) {
+        obj0[j] = obj[j % 9];
+        clbd0[j] = 0.0;
+        cubd0[j] = 1e+20;
+        ctype0[j] = j % 9 < 3 ? 'I' : 'C';
+    }
+
+    ((void (*)(
+        void *,
+        int,
+        int,
+        int,
+        int,
+        int*,
+        int*,
+        double*,
+        double*,
+        double*,
+        char*,
+        double*,
+        double*,
+        double*
+    ))dlsym(handle, "loadBlockProblem"))(
+        env,
+        0,
+        nvars,
+        ncons0,
+        start0[ncons0],
+        start0,
+        index0,
+        value0,
+        clbd0,
+        cubd0,
+        ctype0,
+        obj0,
+        rlbd0,
+        rubd0
+    );
+
+    int *index_ = new int [start1[ncons1]];
+    double *value_ = new double [start1[ncons1]];
+
+    // create each block
+    for (int block = 0; block < 3; block++) {
+        for (int j = 0; j < start1[ncons1]; ++j) {
+            index_[j] = index1[j] + block * 9;
+            if (block == 0) value_[j] = value1[j];
+            else if (block == 1) value_[j] = value2[j];
+            else if (block == 2) value_[j] = value3[j];
+        }
+        ((void (*)(
+            void *,
+            int,
+            int,
+            int,
+            int,
+            int*,
+            int*,
+            double*,
+            double*,
+            double*,
+            char*,
+            double*,
+            double*,
+            double*
+        ))dlsym(handle, "loadBlockProblem"))(
+            env,
+            block + 1,
+            nvars,
+            ncons1,
+            start1[ncons1],
+            start1,
+            index_,
+            value_,
+            clbd0,
+            cubd0,
+            ctype0,
+            obj0,
+            rlbd1,
+            rubd1
+        );
+    }
+
+    // Important to call this!
+    ((void (*)(void*))dlsym(handle, "updateBlocks"))(env);
+
+    
+    // ((void (*)(void*))dlsym(handle, "solveDe"))(env); // solve the deterministic equivalent problem
+    ((void (*)(void*))dlsym(handle, "solveDw"))(env); // solve the Dantzig-Wolfe decomposition
+
+    double primal_bound = ((double (*)(void*))dlsym(handle, "getPrimalBound"))(env);
+    printf("Primal bound = %e\n", primal_bound);
+
+    double *solution = new double [nvars];
+    ((void (*)(void*, int, double*))dlsym(handle, "getPrimalSolution"))(env, nvars, solution);
+    for (int j = 0; j < nvars; ++j) {
+        printf("var%2d = %f\n", j, solution[j]);
+    }
+    // ((void (*)(void*, const char*))dlsym(handle, "writeMps"))(env, "farmer");
+    
+    if (env != NULL) {
+        ((void (*)(void*&))dlsym(handle, "freeEnv"))(env);
+        env = NULL;
+        printf("Successfully freed DSP environment.\n");
+    }
+    dlclose(handle);
+
+    delete [] obj0;
+    delete [] clbd0;
+    delete [] cubd0;
+    delete [] ctype0;
+    delete [] index_;
+    delete [] value_;
+    delete [] solution;
+
+    return 0;
+}

--- a/src/Solver/DantzigWolfe/DwWorker.cpp
+++ b/src/Solver/DantzigWolfe/DwWorker.cpp
@@ -273,11 +273,31 @@ DSP_RTN_CODE DwWorker::generateCols(
 
 			if (status == DSP_STAT_DUAL_INFEASIBLE) {
 				/** retrieve ray if unbounded */
-				std::vector<double*> rays = osi_[s]->si_->getPrimalRays(1);
+				std::vector<double*> rays;
+
+				switch(par_->getIntParam("DW/SUB/SOLVER")) {
+				case OsiCpx:
+					rays = osi_[s]->si_->getPrimalRays(1);
+					break;
+				case OsiGrb:
+					rays = osi_[s]->si_->getPrimalRays(1);
+					// throw CoinError("getPrimalRays not implemented in Gurobi.", "DwWorker", "DwWorker.cpp");
+					break;
+				case OsiScip:
+					// rays = osi_[s]->si_->getPrimalRays(1);
+					throw CoinError("getPrimalRays not implemented in Scip.", "DwWorker", "DwWorker.cpp");
+					break;
+				default:
+					throw CoinError("Invalid paramter value", "DwWorker", "DwWorker.cpp");
+					break;
+				}
+
 				if (rays.size() == 0 || rays[0] == NULL)
 					throw CoinError("No primal ray is available.", "generateCols", "DwWorker");
 				double* ray = rays[0];
 				rays[0] = NULL;
+				DSPdebugMessage("unbounded ray\n");
+				DSPdebug(DspMessage::printArray(osi_[s]->si_->getNumCols(), ray));
 
 				/** subproblem objective value */
 				cx = 0.0;
@@ -310,8 +330,10 @@ DSP_RTN_CODE DwWorker::generateCols(
 				objval = osi_[s]->getPrimObjValue();
 					
 				cx = 0.0;
-				for (int j = 0; j < osi_[s]->si_->getNumCols(); ++j)
+				for (int j = 0; j < osi_[s]->si_->getNumCols(); ++j){
+					DSPdebugMessage("x[%d]: %e\n", j, x[j]);
 					cx += sub_objs_[s][j] * x[j];
+				}
 				DSPdebugMessage("Subprob %d: objval %e, cx %e\n", sind, objval, cx);
 
 				/** subproblem coupling solution */

--- a/src/Solver/DantzigWolfe/DwWorker.cpp
+++ b/src/Solver/DantzigWolfe/DwWorker.cpp
@@ -280,8 +280,8 @@ DSP_RTN_CODE DwWorker::generateCols(
 					rays = osi_[s]->si_->getPrimalRays(1);
 					break;
 				case OsiGrb:
-					rays = osi_[s]->si_->getPrimalRays(1);
-					// throw CoinError("getPrimalRays not implemented in Gurobi.", "DwWorker", "DwWorker.cpp");
+					// rays = osi_[s]->si_->getPrimalRays(1);
+					throw CoinError("getPrimalRays not implemented in Gurobi.", "DwWorker", "DwWorker.cpp");
 					break;
 				case OsiScip:
 					// rays = osi_[s]->si_->getPrimalRays(1);


### PR DESCRIPTION
Clp, Cpx, Msk have implementation of getPrimalRays. We allow only Cpx. If Gurobi or Scip is used, we call CoinError.
Addresses issue https://github.com/Argonne-National-Laboratory/DSP/issues/265.